### PR TITLE
Remove trailing whitespace

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1044,7 +1044,7 @@ impl<T> [T] {
     /// This sort is stable (i.e. does not reorder equal elements) and `O(n log n)` worst-case.
     ///
     /// # Current implementation
-    /// 
+    ///
     /// The current algorithm is an adaptive, iterative merge sort inspired by
     /// [timsort](https://en.wikipedia.org/wiki/Timsort).
     /// It is designed to be very fast in cases where the slice is nearly sorted, or consists of


### PR DESCRIPTION
Like Alex said, there's a trailing whitespace.

`make tidy` passes now.